### PR TITLE
Implemented global menubar

### DIFF
--- a/GWorkspace/Desktop/Dock/Dock.m
+++ b/GWorkspace/Desktop/Dock/Dock.m
@@ -838,7 +838,7 @@
         [icons removeObject: dndSourceIcon];
         [icons insertObject: dndSourceIcon atIndex: index];
         RELEASE (dndSourceIcon);
-        [self  tile];  
+        [self tile];  
         return NSDragOperationMove;    
       }
 

--- a/GWorkspace/Desktop/Dock/Dock.m
+++ b/GWorkspace/Desktop/Dock/Dock.m
@@ -521,13 +521,17 @@
       [icon setIconSize: iconSize];
     }
     
-    icnrect.origin.y -= icnrect.size.height;
-    [icon setFrame: icnrect];
-    
-    if ((targetIndex != -1) && (targetIndex == i)) {
-      icnrect.origin.y -= icnrect.size.height;
-      targetRect = icnrect;
+    if ([icon isTrashIcon]) {
+        icnrect.origin.y = 0;
+    } else {
+        icnrect.origin.y -= icnrect.size.height;
     }
+    
+    targetRect = icnrect;
+
+    [icon setFrame: targetRect];
+    
+    [icon setNeedsDisplayInRect: icon.frame];
   } 
   
   [self setNeedsDisplay: YES];
@@ -834,7 +838,7 @@
         [icons removeObject: dndSourceIcon];
         [icons insertObject: dndSourceIcon atIndex: index];
         RELEASE (dndSourceIcon);
-        [self tile];  
+        [self  tile];  
         return NSDragOperationMove;    
       }
 

--- a/GWorkspace/GWorkspace.m
+++ b/GWorkspace/GWorkspace.m
@@ -41,6 +41,7 @@
 #import "FSNodeRep.h"
 #import "FSNFunctions.h"
 #import "GWorkspace.h"
+#import "GWGlobalMenuWindow.h"
 #import "Dialogs.h"
 #import "OpenWithController.h"
 #import "RunExternalController.h"
@@ -65,6 +66,8 @@ static NSString *defaulteditor = @"nedit.app";
 static NSString *defaultxterm = @"xterm";
 
 static GWorkspace *gworkspace = nil;
+
+static GWGlobalMenuWindow *globalMenu = nil;
 
 @interface	GWorkspace (PrivateMethods)
 - (void)_updateTrashContents;
@@ -518,6 +521,25 @@ static GWorkspace *gworkspace = nil;
   lockpath = [storedAppinfoPath stringByAppendingPathExtension: @"lock"];   
   storedAppinfoLock = [[NSDistributedLock alloc] initWithPath: lockpath];
 
+
+  NSRect screenFrame = [[NSScreen mainScreen] frame];
+  NSRect globalMenuRect = (NSRect){
+    .size = (NSSize){
+      .width = screenFrame.size.width,
+      .height = 22
+    },
+    .origin = (NSPoint){
+      .x = 0,
+      .y = screenFrame.size.height - 20
+    }
+  };
+
+  globalMenu = [[GWGlobalMenuWindow alloc] initWithContentRect: globalMenuRect
+   						     styleMask: NSBorderlessWindowMask
+						       backing: NSBackingStoreBuffered
+							 defer: NO];
+  [globalMenu retain];
+  [globalMenu makeKeyAndOrderFront: self];
   launchedApps = [NSMutableArray new];   
   activeApplication = nil;   
 }


### PR DESCRIPTION
This patch adds the global menubar, which, in combination with a recent
PR to libs-gui, implements the beginnings of menubar functionality roughly
equivalent to that in Mac OS X. At the moment, the global menubar has no
controls or subviews, but it does function more or less as designed.

