### PR TITLE
Altered build system to instal GWorkspace.app and Recycler.app in /System/Library/CoreServices

### DIFF
--- a/GNUmakefile.preamble
+++ b/GNUmakefile.preamble
@@ -27,3 +27,4 @@ ADDITIONAL_TOOL_LIBS +=
 # Additional directories to be created during installation
 ADDITIONAL_INSTALL_DIRS +=
 
+GNUSTEP_INSTALLATION_DOMAIN = SYSTEM


### PR DESCRIPTION
Mac OS X installs various "core" apps that are deeply integrated into the "system" domain,
which means installing into /System/Library/CoreServices instead of /Applications. This
patch alters the GWorkspace build system to do the same.

